### PR TITLE
Fix a classic Go iteration bug

### DIFF
--- a/cmd/block_listener.go
+++ b/cmd/block_listener.go
@@ -57,7 +57,7 @@ type BlockListener struct {
 	Logger           zerolog.Logger
 	Producer         sarama.SyncProducer
 	EventStreamTopic string
-	Registry         map[common.Address]map[common.Hash]*abi.Event
+	Registry         map[common.Address]map[common.Hash]abi.Event
 	Confirmations    *big.Int
 	DB               *sql.DB
 	ABIs             map[common.Address]abi.ABI
@@ -115,7 +115,7 @@ func (bl *BlockListener) CompileRegistryMap(configPath string) {
 
 	err = yaml.Unmarshal(cb, &conf)
 
-	bl.Registry = make(map[common.Address]map[common.Hash]*abi.Event)
+	bl.Registry = make(map[common.Address]map[common.Hash]abi.Event)
 	bl.ABIs = make(map[common.Address]abi.ABI)
 	for _, contract := range conf.Contracts {
 		bl.Contracts = append(bl.Contracts, contract.Address)
@@ -131,11 +131,10 @@ func (bl *BlockListener) CompileRegistryMap(configPath string) {
 		}
 
 		bl.ABIs[contract.Address] = a
-		bl.Registry[contract.Address] = make(map[common.Hash]*abi.Event)
+		bl.Registry[contract.Address] = make(map[common.Hash]abi.Event)
 
 		for _, event := range a.Events {
-			event := event
-			bl.Registry[contract.Address][event.ID] = &event
+			bl.Registry[contract.Address][event.ID] = event
 		}
 	}
 


### PR DESCRIPTION
https://go.dev/play/p/kVdAaOmOKwx

https://go.dev/ref/spec#For_clause

> Variables declared by the init statement are re-used in each iteration.

One way to fix this would be to add `event := event` at the start of the for loop body, but I just killed all the pointers instead. Life is too short.