### PR TITLE
wait for next block

### DIFF
--- a/internal/services/block_listener.go
+++ b/internal/services/block_listener.go
@@ -147,7 +147,7 @@ func (bl *BlockListener) GetNextBlock(block *types.Header) (*types.Header, error
 	nextBlock := new(big.Int).Add(block.Number, big.NewInt(1))
 	head, err := bl.Client.HeaderByNumber(context.Background(), nextBlock)
 
-	if err == ethereum.NotFound && head == nil {
+	if err == ethereum.NotFound {
 		time.Sleep(2 * time.Second)
 		head, err = bl.GetNextBlock(block)
 	}


### PR DESCRIPTION
if the indexer processes blocks faster than new ones are created, wait for the next block before continuing