### PR TITLE
allow start block to be passed and filter contracts

### DIFF
--- a/internal/config/settings.go
+++ b/internal/config/settings.go
@@ -17,4 +17,6 @@ type Settings struct {
 	BlockchainRPCURL string `yaml:"BLOCKCHAIN_RPC_URL"`
 
 	APIKey string `yaml:"ALCHEMY_API_KEY"`
+
+	StartingBlock int64 `yaml:"STARTING_BLOCK"`
 }


### PR DESCRIPTION
uses contract addresses to filter block logs
allows for a start block to be passed-- useful when developing/ testing 
